### PR TITLE
PR_AddingPowerSupport_golang-github-jzelinskie-whirlpool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
+arch:
+  - ppc64le
+  - amd64
 language: go


### PR DESCRIPTION
Adding Power Support.

Adding Power support & making the build run for both arch: amd64/ppc64le.

Adding power support ppc64le
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.